### PR TITLE
fix(Prefabs): update origin position of prefab

### DIFF
--- a/Runtime/Prefabs/Visuals.Vignette.prefab
+++ b/Runtime/Prefabs/Visuals.Vignette.prefab
@@ -328,7 +328,7 @@ GameObject:
   - component: {fileID: 4636666552361120617}
   - component: {fileID: 4636666552361120618}
   m_Layer: 0
-  m_Name: visuals.vignette
+  m_Name: Visuals.Vignette
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -342,7 +342,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4636666552361120619}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.5}
+  m_LocalPosition: {x: 0, y: 0, z: 0.2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4636666552305259391}


### PR DESCRIPTION
The origin position of the prefab has been reduced to 0.2f along the z axis so it is closer to the camera view and reduces the likelihood of showing the external world around the edge of the vignette object.